### PR TITLE
Update to version 1.0.2: Exclude directories starting with a period

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,7 +112,10 @@ async function getFilePaths(dir) {
 
       try {
         if (item.isDirectory()) {
-          if (!["node_modules", ".git", "dist"].includes(item.name)) {
+          if (
+            !["node_modules", "dist"].includes(item.name) &&
+            !item.name.startsWith(".")
+          ) {
             fileList.push(...(await getFilePaths(fullPath)));
           }
         } else if (
@@ -252,7 +255,7 @@ async function selectFiles(fileObjects) {
   return selectedFiles;
 }
 
-// user chooses a prompt
+// let user choose a prompt
 async function selectPrompt() {
   console.log(
     chalk.yellow(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proompt-cat",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI tool for more effective AI interactions",
   "main": "app.js",
   "type": "module",


### PR DESCRIPTION
Issue: tested with a Nuxt3 project and realised we need to exclude .nuxt/ and .output/ folders. 

Fix: exclude all dirs beginning with a period.